### PR TITLE
spelling

### DIFF
--- a/src/app/RunController.cpp
+++ b/src/app/RunController.cpp
@@ -595,9 +595,9 @@ void RunController::stopRun() {
 	//qDebug() << "in RunController::stopRun()";
 	if(!i->isStopping()){
 		// event when the user clicks on the stop button
-		//mainwin->setRunState(RUNSTATESTOPING);
+		//mainwin->setRunState(RUNSTATESTOPPING);
 
-		i->setStatus(R_STOPING);//no more ops
+		i->setStatus(R_STOPPING);//no more ops
 		
 		// wait for speech to stop
 #ifdef Q_OS_WASM

--- a/src/core/Constants.h
+++ b/src/core/Constants.h
@@ -53,7 +53,7 @@
 	#define RUNSTATESTOP 0
 	#define RUNSTATERUN 1
 	#define RUNSTATEDEBUG 2
-	#define RUNSTATESTOPING 3
+	#define RUNSTATESTOPPING 3
 	#define RUNSTATERUNDEBUG 4
 
 	// imagesave valid image types

--- a/src/core/Interpreter.cpp
+++ b/src/core/Interpreter.cpp
@@ -551,8 +551,8 @@ bool Interpreter::isStopped() {
 
 bool Interpreter::isStopping() {
 	// interpreter is stopped or is about to stop
-	// to avoid RunController::stopRun() to be triggered while status == R_STOPING too
-	return (status == R_STOPPED || status == R_STOPING);
+	// to avoid RunController::stopRun() to be triggered while status == R_STOPPING too
+	return (status == R_STOPPED || status == R_STOPPING);
 }
 
 void Interpreter::setStatus(run_status s) {
@@ -1096,8 +1096,8 @@ Interpreter::run() {
 
 void Interpreter::runLoop() {
 	int rv = 0;
-	while (status != R_STOPING && rv==0) {rv = execByteCode();} //continue
-	if (status == R_STOPING && onstopaddr && rv >=0 ) {
+	while (status != R_STOPPING && rv==0) {rv = execByteCode();} //continue
+	if (status == R_STOPPING && onstopaddr && rv >=0 ) {
 		// is there an onstop handler for user event stop
 		// and we are not at a programatic "end"
 		//qDebug() << "onstop" << op;

--- a/src/core/Interpreter.h
+++ b/src/core/Interpreter.h
@@ -81,7 +81,7 @@ class QTcpServer;
     #include <QSerialPort>
 #endif
 
-enum run_status {R_STOPPED, R_RUNNING, R_STOPING, R_PRESTOPING};
+enum run_status {R_STOPPED, R_RUNNING, R_STOPPING, R_PRESTOPPING};
 
 #define NUMFILES 8
 #define NUMSOCKETS 8

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1135,7 +1135,7 @@ void MainWindow::setRunState(int state) {
     debugact->setEnabled(userCanInteractWithGUI && isEditorWindowActive);
     stepact->setEnabled(state==RUNSTATEDEBUG || state==RUNSTATERUNDEBUG);
     bpact->setEnabled(state==RUNSTATEDEBUG);
-    stopact->setEnabled(state!=RUNSTATESTOP && state!=RUNSTATESTOPING);
+    stopact->setEnabled(state!=RUNSTATESTOP && state!=RUNSTATESTOPPING);
     clearbreakpointsact->setEnabled(state!=RUNSTATERUN && isEditorWindowActive);
 
     // Clear command for toolbars
@@ -1146,7 +1146,7 @@ void MainWindow::setRunState(int state) {
 	if (runState==RUNSTATESTOP) statusBar()->showMessage(tr("Ready"));
 	if (runState==RUNSTATERUN) statusBar()->showMessage(tr("Running"));
 	if (runState==RUNSTATEDEBUG) statusBar()->showMessage(tr("Debug"));
-	if (runState==RUNSTATESTOPING) statusBar()->showMessage(tr("Stoping"));
+	if (runState==RUNSTATESTOPPING) statusBar()->showMessage(tr("Stopping"));
 	if (runState==RUNSTATERUNDEBUG) statusBar()->showMessage(tr("Running in Debug"));
 	
 


### PR DESCRIPTION
We want the past tense of "stop", i.e., "stopped", while "stoped" would be the English past tense of the German loan-word "stope", meaning a single excavation in a mine.

Gbp-Pq: Name 0003-spelling.patch